### PR TITLE
Specify minimum node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "type": "git",
     "url": "git+https://github.com/tryghost/gatsby-starter-ghost.git"
   },
+  "engines": {
+    "node": ">= 8.9.0"
+  },
   "bugs": {
     "url": "https://github.com/tryghost/gatsby-starter-ghost/issues"
   },


### PR DESCRIPTION
- Discovered in the [forum](https://forum.ghost.org/t/gatsby-compile-error/5090)
- v8 supports [object spread](https://node.green/#ES2018-features-object-rest-spread-properties-object-spread-properties), but I don't know if this codebase uses v9+ specific features