### PR TITLE
Valid JSON object for website Schema.org metadata

### DIFF
--- a/src/components/common/meta/WebsiteMeta.js
+++ b/src/components/common/meta/WebsiteMeta.js
@@ -35,7 +35,7 @@ const WebsiteMeta = ({ data, settings, canonical, title, description, image, typ
                 <script type="application/ld+json">{`
                     {
                         "@context": "https://schema.org/",
-                        "@type": ${type},
+                        "@type": "${type}",
                         "url": "${canonical}",
                         "image": {
                             "@type": "ImageObject",


### PR DESCRIPTION
Right now, the [Google testing tool](https://search.google.com/structured-data/testing-tool) gives an error because quotes are missing around the type.

```
Syntax error: value, object or array expected.
```