### PR TITLE
Fixing git URL in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gatsby new gatsby-starter-ghost https://github.com/TryGhost/gatsby-starter-ghost
 
 ```bash
 # From Source
-git clone git@github.com:TryGhost/gatsby-starter-ghost.git
+git clone https://github.com/TryGhost/gatsby-starter-ghost.git
 cd gatsby-starter-ghost
 ```
 


### PR DESCRIPTION
For users to clonse the git@github.com URL, they need to be on a machine that's authenticated to Github. The https URL works regardless of whether the user has authenticated.