### PR TITLE
Combine GraphQL queries

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,273 +1,217 @@
 const path = require(`path`)
-const config = require(`./src/utils/siteConfig`)
+const { postsPerPage } = require(`./src/utils/siteConfig`)
 const { paginate } = require(`gatsby-awesome-pagination`)
 
 /**
-* Here is the place where Gatsby creates the URLs for all the
-* posts, tags, pages and authors that we fetched from the Ghost site.
-*/
-exports.createPages = ({ graphql, actions }) => {
+ * Here is the place where Gatsby creates the URLs for all the
+ * posts, tags, pages and authors that we fetched from the Ghost site.
+ */
+exports.createPages = async ({ graphql, actions }) => {
     const { createPage } = actions
 
-    /**
-    * Posts
-    */
-    const createPosts = new Promise((resolve, reject) => {
-        const postTemplate = path.resolve(`./src/templates/post.js`)
-        const indexTemplate = path.resolve(`./src/templates/index.js`)
-        resolve(
-            graphql(`
-                {
-                    allGhostPost(
-                        sort: {order: ASC, fields: published_at}
-                    ) {
-                        edges {
-                            node {
-                                slug
-                            }
-                        }
+    const result = await graphql(`
+        {
+            allGhostPost(sort: { order: ASC, fields: published_at }) {
+                edges {
+                    node {
+                        slug
                     }
-                }`
-            ).then((result) => {
-                if (result.errors) {
-                    return reject(result.errors)
                 }
-
-                if (!result.data.allGhostPost) {
-                    return resolve()
+            }
+            allGhostTag(sort: { order: ASC, fields: name }) {
+                edges {
+                    node {
+                        slug
+                        url
+                        postCount
+                    }
                 }
+            }
+            allGhostAuthor(sort: { order: ASC, fields: name }) {
+                edges {
+                    node {
+                        slug
+                        url
+                        postCount
+                    }
+                }
+            }
+            allGhostPage(sort: { order: ASC, fields: published_at }) {
+                edges {
+                    node {
+                        slug
+                        url
+                    }
+                }
+            }
+            allGhostPage(sort: { order: ASC, fields: published_at }) {
+                edges {
+                    node {
+                        slug
+                        url
+                    }
+                }
+            }
+        }
+    `)
 
-                const items = result.data.allGhostPost.edges
+    // Check for any errors
+    if (result.errors) {
+        throw new Error(result.errors)
+    }
 
-                items.forEach(({ node }) => {
-                    // This part here defines, that our posts will use
-                    // a `/:slug/` permalink.
-                    node.url = `/${node.slug}/`
+    /**
+     * Posts
+     */
+    const postTemplate = path.resolve(`./src/templates/post.js`)
+    const indexTemplate = path.resolve(`./src/templates/index.js`)
+    const posts = result.data.allGhostPost.edges
+    posts.forEach(({ node }) => {
+        // This part here defines, that our posts will use
+        // a `/:slug/` permalink.
+        node.url = `/${node.slug}/`
 
-                    createPage({
-                        path: node.url,
-                        component: postTemplate,
-                        context: {
-                            // Data passed to context is available
-                            // in page queries as GraphQL variables.
-                            slug: node.slug,
-                        },
-                    })
-                })
-
-                // Pagination for posts, e.g., /, /page/2, /page/3
-                paginate({
-                    createPage,
-                    items: items,
-                    itemsPerPage: config.postsPerPage,
-                    component: indexTemplate,
-                    pathPrefix: ({ pageNumber }) => {
-                        if (pageNumber === 0) {
-                            return `/`
-                        } else {
-                            return `/page`
-                        }
-                    },
-                })
-
-                return resolve()
-            })
-        )
+        createPage({
+            path: node.url,
+            component: postTemplate,
+            context: {
+                // Data passed to context is available
+                // in page queries as GraphQL variables.
+                slug: node.slug,
+            },
+        })
     })
 
     /**
-    * Tags
-    */
-    const createTags = new Promise((resolve, reject) => {
-        const tagsTemplate = path.resolve(`./src/templates/tag.js`)
-        resolve(
-            graphql(`
-                {
-                    allGhostTag(
-                        sort: {order: ASC, fields: name}
-                    ) {
-                        edges {
-                            node {
-                                slug
-                                url
-                                postCount
-                            }
-                        }
-                    }
-                }`
-            ).then((result) => {
-                if (result.errors) {
-                    return reject(result.errors)
-                }
-
-                if (!result.data.allGhostTag) {
-                    return resolve()
-                }
-
-                const items = result.data.allGhostTag.edges
-                const postsPerPage = config.postsPerPage
-
-                items.forEach(({ node }) => {
-                    const totalPosts = node.postCount !== null ? node.postCount : 0
-                    const numberOfPages = Math.ceil(totalPosts / postsPerPage)
-
-                    // This part here defines, that our tag pages will use
-                    // a `/tag/:slug/` permalink.
-                    node.url = `/tag/${node.slug}/`
-
-                    Array.from({ length: numberOfPages }).forEach((_, i) => {
-                        const currentPage = i + 1
-                        const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
-                        const nextPageNumber = currentPage + 1 > numberOfPages ? null : currentPage + 1
-                        const previousPagePath = prevPageNumber ? prevPageNumber === 1 ? node.url : `${node.url}page/${prevPageNumber}/` : null
-                        const nextPagePath = nextPageNumber ? `${node.url}page/${nextPageNumber}/` : null
-
-                        createPage({
-                            path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
-                            component: tagsTemplate,
-                            context: {
-                                // Data passed to context is available
-                                // in page queries as GraphQL variables.
-                                slug: node.slug,
-                                limit: postsPerPage,
-                                skip: i * postsPerPage,
-                                numberOfPages: numberOfPages,
-                                humanPageNumber: currentPage,
-                                prevPageNumber: prevPageNumber,
-                                nextPageNumber: nextPageNumber,
-                                previousPagePath: previousPagePath,
-                                nextPagePath: nextPagePath,
-                            },
-                        })
-                    })
-                })
-
-                return resolve()
-            })
-        )
+     * Pagination
+     * post next/previous links, e.g., /, /page/2, /page/3
+     */
+    paginate({
+        createPage,
+        items: posts,
+        itemsPerPage: postsPerPage,
+        component: indexTemplate,
+        pathPrefix: ({ pageNumber }) => {
+            if (pageNumber === 0) {
+                return `/`
+            } else {
+                return `/page`
+            }
+        },
     })
 
     /**
-    * Authors
-    */
-    const createAuthors = new Promise((resolve, reject) => {
-        const authorTemplate = path.resolve(`./src/templates/author.js`)
-        resolve(
-            graphql(`
-                {
-                    allGhostAuthor(
-                        sort: {order: ASC, fields: name}
-                    ) {
-                        edges {
-                            node {
-                                slug
-                                url
-                                postCount
-                            }
-                        }
-                    }
-                }`
-            ).then((result) => {
-                if (result.errors) {
-                    return reject(result.errors)
-                }
+     * Tags
+     */
+    const tagsTemplate = path.resolve(`./src/templates/tag.js`)
+    const tags = result.data.allGhostTag.edges
+    tags.forEach(({ node }) => {
+        const totalPosts = node.postCount !== null ? node.postCount : 0
+        const numberOfPages = Math.ceil(totalPosts / postsPerPage)
 
-                if (!result.data.allGhostAuthor) {
-                    return resolve()
-                }
+        // This part here defines, that our tag pages will use
+        // a `/tag/:slug/` permalink.
+        node.url = `/tag/${node.slug}/`
 
-                const items = result.data.allGhostAuthor.edges
-                const postsPerPage = config.postsPerPage
+        Array.from({ length: numberOfPages }).forEach((_, i) => {
+            const currentPage = i + 1
+            const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
+            const nextPageNumber =
+                currentPage + 1 > numberOfPages ? null : currentPage + 1
+            const previousPagePath = prevPageNumber
+                ? prevPageNumber === 1
+                    ? node.url
+                    : `${node.url}page/${prevPageNumber}/`
+                : null
+            const nextPagePath = nextPageNumber
+                ? `${node.url}page/${nextPageNumber}/`
+                : null
 
-                items.forEach(({ node }) => {
-                    const totalPosts = node.postCount !== null ? node.postCount : 0
-                    const numberOfPages = Math.ceil(totalPosts / postsPerPage)
-
-                    // This part here defines, that our author pages will use
-                    // a `/author/:slug/` permalink.
-                    node.url = `/author/${node.slug}/`
-
-                    Array.from({ length: numberOfPages }).forEach((_, i) => {
-                        const currentPage = i + 1
-                        const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
-                        const nextPageNumber = currentPage + 1 > numberOfPages ? null : currentPage + 1
-                        const previousPagePath = prevPageNumber ? prevPageNumber === 1 ? node.url : `${node.url}page/${prevPageNumber}/` : null
-                        const nextPagePath = nextPageNumber ? `${node.url}page/${nextPageNumber}/` : null
-
-                        createPage({
-                            path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
-                            component: authorTemplate,
-                            context: {
-                                // Data passed to context is available
-                                // in page queries as GraphQL variables.
-                                slug: node.slug,
-                                limit: postsPerPage,
-                                skip: i * postsPerPage,
-                                numberOfPages: numberOfPages,
-                                humanPageNumber: currentPage,
-                                prevPageNumber: prevPageNumber,
-                                nextPageNumber: nextPageNumber,
-                                previousPagePath: previousPagePath,
-                                nextPagePath: nextPagePath,
-                            },
-                        })
-                    })
-                })
-                return resolve()
+            createPage({
+                path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
+                component: tagsTemplate,
+                context: {
+                    // Data passed to context is available
+                    // in page queries as GraphQL variables.
+                    slug: node.slug,
+                    limit: postsPerPage,
+                    skip: i * postsPerPage,
+                    numberOfPages: numberOfPages,
+                    humanPageNumber: currentPage,
+                    prevPageNumber: prevPageNumber,
+                    nextPageNumber: nextPageNumber,
+                    previousPagePath: previousPagePath,
+                    nextPagePath: nextPagePath,
+                },
             })
-        )
+        })
     })
 
     /**
-    * Pages
-    */
-    const createPages = new Promise((resolve, reject) => {
-        const pageTemplate = path.resolve(`./src/templates/page.js`)
-        resolve(
-            graphql(`
-                {
-                    allGhostPage(
-                        sort: {order: ASC, fields: published_at}
-                    ) {
-                        edges {
-                            node {
-                                slug
-                                url
-                            }
-                        }
-                    }
-                }`
-            ).then((result) => {
-                if (result.errors) {
-                    return reject(result.errors)
-                }
+     * Authors
+     */
+    const authorTemplate = path.resolve(`./src/templates/author.js`)
+    const authors = result.data.allGhostAuthor.edges
+    authors.forEach(({ node }) => {
+        const totalPosts = node.postCount !== null ? node.postCount : 0
+        const numberOfPages = Math.ceil(totalPosts / postsPerPage)
 
-                if (!result.data.allGhostPage) {
-                    return resolve()
-                }
+        // This part here defines, that our author pages will use
+        // a `/author/:slug/` permalink.
+        node.url = `/author/${node.slug}/`
 
-                const items = result.data.allGhostPage.edges
+        Array.from({ length: numberOfPages }).forEach((_, i) => {
+            const currentPage = i + 1
+            const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
+            const nextPageNumber =
+                currentPage + 1 > numberOfPages ? null : currentPage + 1
+            const previousPagePath = prevPageNumber
+                ? prevPageNumber === 1
+                    ? node.url
+                    : `${node.url}page/${prevPageNumber}/`
+                : null
+            const nextPagePath = nextPageNumber
+                ? `${node.url}page/${nextPageNumber}/`
+                : null
 
-                items.forEach(({ node }) => {
-                    // This part here defines, that our pages will use
-                    // a `/:slug/` permalink.
-                    node.url = `/${node.slug}/`
-
-                    createPage({
-                        path: node.url,
-                        component: pageTemplate,
-                        context: {
-                            // Data passed to context is available
-                            // in page queries as GraphQL variables.
-                            slug: node.slug,
-                        },
-                    })
-                })
-
-                return resolve()
+            createPage({
+                path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
+                component: authorTemplate,
+                context: {
+                    // Data passed to context is available
+                    // in page queries as GraphQL variables.
+                    slug: node.slug,
+                    limit: postsPerPage,
+                    skip: i * postsPerPage,
+                    numberOfPages: numberOfPages,
+                    humanPageNumber: currentPage,
+                    prevPageNumber: prevPageNumber,
+                    nextPageNumber: nextPageNumber,
+                    previousPagePath: previousPagePath,
+                    nextPagePath: nextPagePath,
+                },
             })
-        )
+        })
     })
 
-    return Promise.all([createPosts, createTags, createAuthors, createPages])
+    /**
+     * Pages
+     */
+    const pageTemplate = path.resolve(`./src/templates/page.js`)
+    const pages = result.data.allGhostPage.edges
+    pages.forEach(({ node }) => {
+        // This part here defines, that our pages will use
+        // a `/:slug/` permalink.
+        node.url = `/${node.slug}/`
+
+        createPage({
+            path: node.url,
+            component: pageTemplate,
+            context: {
+                // Data passed to context is available
+                // in page queries as GraphQL variables.
+                slug: node.slug,
+            },
+        })
+    })
 }

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -60,51 +60,20 @@ exports.createPages = async ({ graphql, actions }) => {
         throw new Error(result.errors)
     }
 
-    /**
-     * Posts
-     */
-    const postTemplate = path.resolve(`./src/templates/post.js`)
-    const indexTemplate = path.resolve(`./src/templates/index.js`)
-    const posts = result.data.allGhostPost.edges
-    posts.forEach(({ node }) => {
-        // This part here defines, that our posts will use
-        // a `/:slug/` permalink.
-        node.url = `/${node.slug}/`
-
-        createPage({
-            path: node.url,
-            component: postTemplate,
-            context: {
-                // Data passed to context is available
-                // in page queries as GraphQL variables.
-                slug: node.slug,
-            },
-        })
-    })
-
-    /**
-     * Pagination
-     * post next/previous links, e.g., /, /page/2, /page/3
-     */
-    paginate({
-        createPage,
-        items: posts,
-        itemsPerPage: postsPerPage,
-        component: indexTemplate,
-        pathPrefix: ({ pageNumber }) => {
-            if (pageNumber === 0) {
-                return `/`
-            } else {
-                return `/page`
-            }
-        },
-    })
-
-    /**
-     * Tags
-     */
-    const tagsTemplate = path.resolve(`./src/templates/tag.js`)
+    // Extract query results
     const tags = result.data.allGhostTag.edges
+    const authors = result.data.allGhostAuthor.edges
+    const pages = result.data.allGhostPage.edges
+    const posts = result.data.allGhostPost.edges
+
+    // Load templates
+    const indexTemplate = path.resolve(`./src/templates/index.js`)
+    const tagsTemplate = path.resolve(`./src/templates/tag.js`)
+    const authorTemplate = path.resolve(`./src/templates/author.js`)
+    const pageTemplate = path.resolve(`./src/templates/page.js`)
+    const postTemplate = path.resolve(`./src/templates/post.js`)
+
+    // Create tag pages
     tags.forEach(({ node }) => {
         const totalPosts = node.postCount !== null ? node.postCount : 0
         const numberOfPages = Math.ceil(totalPosts / postsPerPage)
@@ -147,11 +116,7 @@ exports.createPages = async ({ graphql, actions }) => {
         })
     })
 
-    /**
-     * Authors
-     */
-    const authorTemplate = path.resolve(`./src/templates/author.js`)
-    const authors = result.data.allGhostAuthor.edges
+    // Create author pages
     authors.forEach(({ node }) => {
         const totalPosts = node.postCount !== null ? node.postCount : 0
         const numberOfPages = Math.ceil(totalPosts / postsPerPage)
@@ -194,11 +159,7 @@ exports.createPages = async ({ graphql, actions }) => {
         })
     })
 
-    /**
-     * Pages
-     */
-    const pageTemplate = path.resolve(`./src/templates/page.js`)
-    const pages = result.data.allGhostPage.edges
+    // Create pages
     pages.forEach(({ node }) => {
         // This part here defines, that our pages will use
         // a `/:slug/` permalink.
@@ -213,5 +174,37 @@ exports.createPages = async ({ graphql, actions }) => {
                 slug: node.slug,
             },
         })
+    })
+
+    // Create post pages
+    posts.forEach(({ node }) => {
+        // This part here defines, that our posts will use
+        // a `/:slug/` permalink.
+        node.url = `/${node.slug}/`
+
+        createPage({
+            path: node.url,
+            component: postTemplate,
+            context: {
+                // Data passed to context is available
+                // in page queries as GraphQL variables.
+                slug: node.slug,
+            },
+        })
+    })
+
+    // Create pagination
+    paginate({
+        createPage,
+        items: posts,
+        itemsPerPage: postsPerPage,
+        component: indexTemplate,
+        pathPrefix: ({ pageNumber }) => {
+            if (pageNumber === 0) {
+                return `/`
+            } else {
+                return `/page`
+            }
+        },
     })
 }


### PR DESCRIPTION
This PR combines GraphQL queries to cut down on network requests. It also destructures siteConfig when it's required to explicitly show which options are being used and introduces async/await to cut down on indentation. I grouped the templates & data extraction together as it felt cleaner, but I can revert it if needed.

Hope it helps!