### PR TITLE
Add Apple Touch Icons

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -74,6 +74,7 @@ module.exports = {
                 theme_color: config.themeColor,
                 display: `minimal-ui`,
                 icon: `static/${config.siteIcon}`,
+                legacy: true,
                 query: `
                 {
                     allGhostSettings {


### PR DESCRIPTION
Add `apple-touch-icon` via Gatsby Manifest Plugin
PWA - Lighthouse Test Shown Warning Apple Touch Icons Missing in the <head>

![Screenshot from 2019-08-05 10-09-17](https://user-images.githubusercontent.com/10300271/62439339-1dbebf80-b769-11e9-92da-54d635fa6421.png)

Reference - https://github.com/gatsbyjs/gatsby/issues/10770#issuecomment-450839464

Set `legacy: true,` in `gatsby-plugin-ghost-manifest` Plugin Configuration
