### PR TITLE
Added gatsby-plugin-catch-links & Missing PropTypes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -179,6 +179,7 @@ module.exports = {
                 addUncaughtPages: true,
             },
         },
+        `gatsby-plugin-catch-links`,
         `gatsby-plugin-react-helmet`,
         `gatsby-plugin-force-trailing-slashes`,
         `gatsby-plugin-offline`,

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gatsby-awesome-pagination": "0.3.4",
     "gatsby-image": "2.2.7",
     "gatsby-plugin-advanced-sitemap": "1.4.0",
+    "gatsby-plugin-catch-links": "^2.1.5",
     "gatsby-plugin-feed": "2.3.6",
     "gatsby-plugin-force-trailing-slashes": "1.0.4",
     "gatsby-plugin-manifest": "2.2.4",

--- a/src/components/common/Layout.js
+++ b/src/components/common/Layout.js
@@ -102,6 +102,7 @@ DefaultLayout.propTypes = {
     bodyClass: PropTypes.string,
     isHome: PropTypes.bool,
     data: PropTypes.shape({
+        file: PropTypes.object,
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
 }

--- a/src/components/common/PostCard.js
+++ b/src/components/common/PostCard.js
@@ -40,6 +40,7 @@ const PostCard = ({ post }) => {
 
 PostCard.propTypes = {
     post: PropTypes.shape({
+        slug: PropTypes.string.isRequired,
         title: PropTypes.string.isRequired,
         feature_image: PropTypes.string,
         featured: PropTypes.bool,

--- a/src/components/common/meta/ArticleMeta.js
+++ b/src/components/common/meta/ArticleMeta.js
@@ -142,6 +142,9 @@ ArticleMetaGhost.propTypes = {
         excerpt: PropTypes.string.isRequired,
     }).isRequired,
     settings: PropTypes.shape({
+        logo: PropTypes.object,
+        title: PropTypes.string,
+        twitter: PropTypes.string,
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
     canonical: PropTypes.string.isRequired,

--- a/src/components/common/meta/AuthorMeta.js
+++ b/src/components/common/meta/AuthorMeta.js
@@ -68,6 +68,9 @@ AuthorMeta.propTypes = {
         facebook: PropTypes.string,
     }).isRequired,
     settings: PropTypes.shape({
+        title: PropTypes.string,
+        twitter: PropTypes.string,
+        description: PropTypes.string,
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
     canonical: PropTypes.string.isRequired,

--- a/src/components/common/meta/WebsiteMeta.js
+++ b/src/components/common/meta/WebsiteMeta.js
@@ -72,12 +72,19 @@ const WebsiteMeta = ({ data, settings, canonical, title, description, image, typ
 WebsiteMeta.propTypes = {
     data: PropTypes.shape({
         title: PropTypes.string,
+        meta_title: PropTypes.string,
+        meta_description: PropTypes.string,
+        name: PropTypes.string,
         feature_image: PropTypes.string,
         description: PropTypes.string,
         bio: PropTypes.string,
         profile_image: PropTypes.string,
     }).isRequired,
     settings: PropTypes.shape({
+        logo: PropTypes.object,
+        description: PropTypes.string,
+        title: PropTypes.string,
+        twitter: PropTypes.string,
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
     canonical: PropTypes.string.isRequired,

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -45,6 +45,7 @@ const Page = ({ data, location }) => {
 Page.propTypes = {
     data: PropTypes.shape({
         ghostPage: PropTypes.shape({
+            codeinjection_styles: PropTypes.object,
             title: PropTypes.string.isRequired,
             html: PropTypes.string.isRequired,
             feature_image: PropTypes.string,

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -51,6 +51,7 @@ const Post = ({ data, location }) => {
 Post.propTypes = {
     data: PropTypes.shape({
         ghostPost: PropTypes.shape({
+            codeinjection_styles: PropTypes.object,
             title: PropTypes.string.isRequired,
             html: PropTypes.string.isRequired,
             feature_image: PropTypes.string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -718,7 +718,7 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.11.1"
 
-"@babel/runtime@7.5.5":
+"@babel/runtime@7.5.5", "@babel/runtime@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
   integrity sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==
@@ -5011,6 +5011,14 @@ gatsby-plugin-advanced-sitemap@1.4.0:
     lodash "4.17.15"
     moment "^2.24.0"
     xml "^1.0.1"
+
+gatsby-plugin-catch-links@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-catch-links/-/gatsby-plugin-catch-links-2.1.5.tgz#de84abd4a1dc60958ef9fa9e64438bbaea65b8a0"
+  integrity sha512-YL4heo4WtELBRDGejERNfDOSNZzXFnjQAbEwYk09vkTczWd0NO3BUeVpfK3bJY0Md+5ELiCxQSV0xDBle8ddeQ==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    escape-string-regexp "^1.0.5"
 
 gatsby-plugin-feed@2.3.6:
   version "2.3.6"


### PR DESCRIPTION
This commit for `gatsby-plugin-catch-links` avoids the browser having to refresh the whole page when navigating between local pages, preserving the Single Page Application (SPA) feel as `a` tags are added by the Headless Ghost CMS and not within the actual source code. I also added the remaining PropTypes not in the original source code.