### PR TITLE
Stringify JSON-LD

### DIFF
--- a/src/components/common/meta/ArticleMeta.js
+++ b/src/components/common/meta/ArticleMeta.js
@@ -21,6 +21,43 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
     const shareImage = ghostPost.feature_image ? ghostPost.feature_image : _.get(settings, `cover_image`, null)
     const publisherLogo = (settings.logo || config.siteIcon) ? url.resolve(config.siteUrl, (settings.logo || config.siteIcon)) : null
 
+    const jsonLd = {
+        "@context": `https://schema.org/`,
+        "@type": `Article`,
+        author: {
+            "@type": `Person`,
+            name: author.name,
+            image: author.image ? author.image : undefined,
+            sameAs: author.sameAsArray ? author.sameAsArray : undefined,
+        },
+        keywords: publicTags.length ? publicTags.join(`, `) : undefined,
+        headline: ghostPost.meta_title || ghostPost.title,
+        url: canonical,
+        datePublished: ghostPost.published_at,
+        dateModified: ghostPost.updated_at,
+        image: shareImage ? {
+            "@type": `ImageObject`,
+            url: shareImage,
+            width: config.shareImageWidth,
+            height: config.shareImageHeight,
+        } : undefined,
+        publisher: {
+            "@type": `Organization`,
+            name: settings.title,
+            logo: {
+                "@type": `ImageObject`,
+                url: publisherLogo,
+                width: 60,
+                height: 60,
+            },
+        },
+        description: ghostPost.meta_description || ghostPost.excerpt,
+        mainEntityOfPage: {
+            "@type": `WebPage`,
+            "@id": config.siteUrl,
+        },
+    }
+
     return (
         <>
             <Helmet>
@@ -72,44 +109,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
 
                 {settings.twitter && <meta name="twitter:site" content={`https://twitter.com/${settings.twitter.replace(/^@/, ``)}/`} />}
                 {settings.twitter && <meta name="twitter:creator" content={settings.twitter} />}
-                <script type="application/ld+json">{`
-                    {
-                        "@context": "https://schema.org/",
-                        "@type": "Article",
-                        "author": {
-                            "@type": "Person",
-                            "name": "${author.name}",
-                            ${author.image ? author.sameAsArray ? `"image": "${author.image}",` : `"image": "${author.image}"` : ``}
-                            ${author.sameAsArray ? `"sameAs": ${author.sameAsArray}` : ``}
-                        },
-                        ${publicTags.length ? `"keywords": "${_.join(publicTags, `, `)}",` : ``}
-                        "headline": "${ghostPost.meta_title || ghostPost.title}",
-                        "url": "${canonical}",
-                        "datePublished": "${ghostPost.published_at}",
-                        "dateModified": "${ghostPost.updated_at}",
-                        ${shareImage ? `"image": {
-                                "@type": "ImageObject",
-                                "url": "${shareImage}",
-                                "width": "${config.shareImageWidth}",
-                                "height": "${config.shareImageHeight}"
-                            },` : ``}
-                        "publisher": {
-                            "@type": "Organization",
-                            "name": "${settings.title}",
-                            "logo": {
-                                "@type": "ImageObject",
-                                "url": "${publisherLogo}",
-                                "width": 60,
-                                "height": 60
-                            }
-                        },
-                        "description": "${ghostPost.meta_description || ghostPost.excerpt}",
-                        "mainEntityOfPage": {
-                            "@type": "WebPage",
-                            "@id": "${config.siteUrl}"
-                        }
-                    }
-                `}</script>
+                <script type="application/ld+json">{JSON.stringify(jsonLd, undefined, 4)}</script>
             </Helmet>
             <ImageMeta image={shareImage} />
         </>

--- a/src/components/common/meta/AuthorMeta.js
+++ b/src/components/common/meta/AuthorMeta.js
@@ -16,6 +16,25 @@ const AuthorMeta = ({ data, settings, canonical }) => {
     const title = `${data.name} - ${settings.title}`
     const description = data.bio || config.siteDescriptionMeta || settings.description
 
+    const jsonLd = {
+        "@context": `https://schema.org/`,
+        "@type": `Person`,
+        name: data.name,
+        sameAs: author.sameAsArray ? author.sameAsArray : undefined,
+        url: canonical,
+        image: shareImage ? {
+            "@type": `ImageObject`,
+            url: shareImage,
+            width: config.shareImageWidth,
+            height: config.shareImageHeight,
+        } : undefined,
+        mainEntityOfPage: {
+            "@type": `WebPage`,
+            "@id": config.siteUrl,
+        },
+        description,
+    }
+
     return (
         <>
             <Helmet>
@@ -32,26 +51,7 @@ const AuthorMeta = ({ data, settings, canonical }) => {
                 <meta name="twitter:url" content={canonical} />
                 {settings.twitter && <meta name="twitter:site" content={`https://twitter.com/${settings.twitter.replace(/^@/, ``)}/`} />}
                 {settings.twitter && <meta name="twitter:creator" content={settings.twitter} />}
-                <script type="application/ld+json">{`
-                    {
-                        "@context": "https://schema.org/",
-                        "@type": "Person",
-                        "name": "${data.name}",
-                        ${author.sameAsArray ? `"sameAs": ${author.sameAsArray},` : ``}
-                        "url": "${canonical}",
-                        ${shareImage ? `"image": {
-                                "@type": "ImageObject",
-                                "url": "${shareImage}",
-                                "width": "${config.shareImageWidth}",
-                                "height": "${config.shareImageHeight}"
-                            },` : ``}
-                        "mainEntityOfPage": {
-                            "@type": "WebPage",
-                            "@id": "${config.siteUrl}"
-                        },
-                        "description": "${description}"
-                    }
-                `}</script>
+                <script type="application/ld+json">{JSON.stringify(jsonLd, undefined, 4)}</script>
             </Helmet>
             <ImageMeta image={shareImage} />
         </>

--- a/src/components/common/meta/WebsiteMeta.js
+++ b/src/components/common/meta/WebsiteMeta.js
@@ -19,6 +19,34 @@ const WebsiteMeta = ({ data, settings, canonical, title, description, image, typ
     description = description || data.meta_description || data.description || config.siteDescriptionMeta || settings.description
     title = `${title || data.meta_title || data.name || data.title} - ${settings.title}`
 
+    const jsonLd = {
+        "@context": `https://schema.org/`,
+        "@type": type,
+        url: canonical,
+        image: shareImage ?
+            {
+                "@type": `ImageObject`,
+                url: shareImage,
+                width: config.shareImageWidth,
+                height: config.shareImageHeight,
+            } : undefined,
+        publisher: {
+            "@type": `Organization`,
+            name: settings.title,
+            logo: {
+                "@type": `ImageObject`,
+                url: publisherLogo,
+                width: 60,
+                height: 60,
+            },
+        },
+        mainEntityOfPage: {
+            "@type": `WebPage`,
+            "@id": config.siteUrl,
+        },
+        description,
+    }
+
     return (
         <>
             <Helmet>
@@ -35,34 +63,7 @@ const WebsiteMeta = ({ data, settings, canonical, title, description, image, typ
                 <meta name="twitter:url" content={canonical} />
                 {settings.twitter && <meta name="twitter:site" content={`https://twitter.com/${settings.twitter.replace(/^@/, ``)}/`} />}
                 {settings.twitter && <meta name="twitter:creator" content={settings.twitter} />}
-                <script type="application/ld+json">{`
-                    {
-                        "@context": "https://schema.org/",
-                        "@type": "${type}",
-                        "url": "${canonical}",
-                        ${shareImage ? `"image": {
-                                "@type": "ImageObject",
-                                "url": "${shareImage}",
-                                "width": "${config.shareImageWidth}",
-                                "height": "${config.shareImageHeight}"
-                            },` : ``}
-                        "publisher": {
-                            "@type": "Organization",
-                            "name": "${settings.title}",
-                            "logo": {
-                                "@type": "ImageObject",
-                                "url": "${publisherLogo}",
-                                "width": 60,
-                                "height": 60
-                            }
-                        },
-                        "mainEntityOfPage": {
-                            "@type": "WebPage",
-                            "@id": "${config.siteUrl}"
-                        },
-                        "description": "${description}"
-                    }
-                `}</script>
+                <script type="application/ld+json">{JSON.stringify(jsonLd, undefined, 4)}</script>
             </Helmet>
             <ImageMeta image={shareImage} />
         </>


### PR DESCRIPTION
Stringifying JSON is much more reliable than hand-assembling it. It's also easier to read and maintain.

`JSON.stringify({foo: undefined})` is `'{}'` so there's no problem dealing with the conditional includes this way.

Fix #89