### PR TITLE
Render post URLs in RSS feed with correct site URL

### DIFF
--- a/src/utils/rss/generate-feed.js
+++ b/src/utils/rss/generate-feed.js
@@ -2,8 +2,8 @@ const cheerio = require(`cheerio`)
 const tagsHelper = require(`@tryghost/helpers`).tags
 const _ = require(`lodash`)
 
-const generateItem = function generateItem(post) {
-    const itemUrl = post.canonical_url || post.url
+const generateItem = function generateItem(siteUrl, post) {
+    const itemUrl = post.canonical_url || `${siteUrl}/${post.slug}/`
     const html = post.html
     const htmlContent = cheerio.load(html, { decodeEntities: false, xmlMode: true })
     const item = {
@@ -46,7 +46,7 @@ const generateItem = function generateItem(post) {
 
 const generateRSSFeed = function generateRSSFeed(siteConfig) {
     return {
-        serialize: ({ query: { allGhostPost } }) => allGhostPost.edges.map(edge => Object.assign({}, generateItem(edge.node))),
+        serialize: ({ query: { allGhostPost } }) => allGhostPost.edges.map(edge => Object.assign({}, generateItem(siteConfig.siteUrl, edge.node))),
         setup: ({ query: { allGhostSettings } }) => {
             const siteTitle = allGhostSettings.edges[0].node.title || `No Title`
             const siteDescription = allGhostSettings.edges[0].node.description || `No Description`


### PR DESCRIPTION
### Summary

RSS feeds generated by `generate-feed.js` construct post URLs from Ghost admin as opposed to `siteConfig.siteUrl`. Post URLs should reference URLs of the current theme, as opposed to the `apiUrl` of Ghost admin.

### To Reproduce

1. Source content from a source in **.ghost.json**.
2. Set a site URL in **sitConfig.js**.
3. Run `gatsby build && gatsby serve`
4. Inspect the resulting post URLs in the RSS feed at **http://localhost:9000/rss**
5. Notice that post URLs do not reference posts living on the current Gatsby theme, but rather the Ghost source

Issue found here: https://github.com/TryGhost/gatsby-starter-ghost/issues/80