### PR TITLE
Add secondary_navigation to fragments.js (#1)

### DIFF
--- a/src/utils/fragments.js
+++ b/src/utils/fragments.js
@@ -241,5 +241,9 @@ export const ghostSettingsFields = graphql`
             label
             url
         }
+        secondary_navigation {
+            label
+            url
+        }
     }
 `


### PR DESCRIPTION
When I was playing around in `Layout.js` to add my `secondary_navigation`, I was getting errors and noticed that this field wasn’t mapped in fragments.js. Adding this for completeness :) 