### PR TITLE
Ignore environment configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ typings/
 
 # dotenv environment variables file
 .env
+.env.development
+.env.production
 
 # IDE
 .idea/*


### PR DESCRIPTION
Gatsby makes active use of `.env.*` files. It's better to ignore the most common ones. Source: https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript