### PR TITLE
Update gatsby-node for consistency using paginate for Tags and Authors

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -68,86 +68,46 @@ exports.createPages = async ({ graphql, actions }) => {
     // Create tag pages
     tags.forEach(({ node }) => {
         const totalPosts = node.postCount !== null ? node.postCount : 0
-        const numberOfPages = Math.ceil(totalPosts / postsPerPage)
 
         // This part here defines, that our tag pages will use
         // a `/tag/:slug/` permalink.
-        node.url = `/tag/${node.slug}/`
+        const url = `/tag/${node.slug}`
 
-        Array.from({ length: numberOfPages }).forEach((_, i) => {
-            const currentPage = i + 1
-            const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
-            const nextPageNumber =
-                currentPage + 1 > numberOfPages ? null : currentPage + 1
-            const previousPagePath = prevPageNumber
-                ? prevPageNumber === 1
-                    ? node.url
-                    : `${node.url}page/${prevPageNumber}/`
-                : null
-            const nextPagePath = nextPageNumber
-                ? `${node.url}page/${nextPageNumber}/`
-                : null
+        const items = Array.from({length: totalPosts})
 
-            createPage({
-                path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
-                component: tagsTemplate,
-                context: {
-                    // Data passed to context is available
-                    // in page queries as GraphQL variables.
-                    slug: node.slug,
-                    limit: postsPerPage,
-                    skip: i * postsPerPage,
-                    numberOfPages: numberOfPages,
-                    humanPageNumber: currentPage,
-                    prevPageNumber: prevPageNumber,
-                    nextPageNumber: nextPageNumber,
-                    previousPagePath: previousPagePath,
-                    nextPagePath: nextPagePath,
-                },
-            })
+        // Create pagination
+        paginate({
+            createPage,
+            items: items,
+            itemsPerPage: postsPerPage,
+            component: tagsTemplate,
+            pathPrefix: ({ pageNumber }) => (pageNumber === 0) ? url : `${url}/page`,
+            context: {
+                slug: node.slug
+            }
         })
     })
 
     // Create author pages
     authors.forEach(({ node }) => {
         const totalPosts = node.postCount !== null ? node.postCount : 0
-        const numberOfPages = Math.ceil(totalPosts / postsPerPage)
 
         // This part here defines, that our author pages will use
         // a `/author/:slug/` permalink.
-        node.url = `/author/${node.slug}/`
+        const url = `/author/${node.slug}`
 
-        Array.from({ length: numberOfPages }).forEach((_, i) => {
-            const currentPage = i + 1
-            const prevPageNumber = currentPage <= 1 ? null : currentPage - 1
-            const nextPageNumber =
-                currentPage + 1 > numberOfPages ? null : currentPage + 1
-            const previousPagePath = prevPageNumber
-                ? prevPageNumber === 1
-                    ? node.url
-                    : `${node.url}page/${prevPageNumber}/`
-                : null
-            const nextPagePath = nextPageNumber
-                ? `${node.url}page/${nextPageNumber}/`
-                : null
+        const items = Array.from({length: totalPosts})
 
-            createPage({
-                path: i === 0 ? node.url : `${node.url}page/${i + 1}/`,
-                component: authorTemplate,
-                context: {
-                    // Data passed to context is available
-                    // in page queries as GraphQL variables.
-                    slug: node.slug,
-                    limit: postsPerPage,
-                    skip: i * postsPerPage,
-                    numberOfPages: numberOfPages,
-                    humanPageNumber: currentPage,
-                    prevPageNumber: prevPageNumber,
-                    nextPageNumber: nextPageNumber,
-                    previousPagePath: previousPagePath,
-                    nextPagePath: nextPagePath,
-                },
-            })
+        // Create pagination
+        paginate({
+            createPage,
+            items: items,
+            itemsPerPage: postsPerPage,
+            component: authorTemplate,
+            pathPrefix: ({ pageNumber }) => (pageNumber === 0) ? url : `${url}/page`,
+            context: {
+                slug: node.slug
+            }
         })
     })
 


### PR DESCRIPTION
Looking at this repo as a reference on how to use the `gatsby-source-ghost` plugin, I just realized there was some code duplication between `gatsby-awesome-pagination` that is being used for the index page, and the one used for Tags/Authors' scripts in `gatsby-node.js`. 

I created an empty array of `items` to use the `paginate` method in the "correct" way, and avoid to reimplement the pagination function.

I believe it's a cleaner code and a little bit more consistent. I hope you can find this useful :)