### PR TITLE
Upgrade GatsbyJS version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tryghost/helpers": "1.1.52",
     "@tryghost/helpers-gatsby": "1.0.57",
     "cheerio": "1.0.0-rc.9",
-    "gatsby": "3.12.1",
+    "gatsby": "3.13.1",
     "gatsby-awesome-pagination": "0.3.8",
     "gatsby-image": "3.11.0",
     "gatsby-plugin-advanced-sitemap": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "4.17.21",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-helmet": "6.1.0"
+    "react-helmet": "6.1.0",
+    "url": "^0.11.0"
   }
 }


### PR DESCRIPTION
This PR resolves two issues:

- #428 by upgrading Gatsby to use a new version of webpack
- Install URL module to fix `webpack < 5 used to include polyfills for node.js `

