### PR TITLE
Fixed package.json lint script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,59 +1,63 @@
 module.exports = {
-    'parser': 'babel-eslint',
-    'parserOptions': {
-        'ecmaVersion': 6,
-        'ecmaFeatures': {
-            'jsx': true,
-            'experimentalObjectRestSpread': true
-        }
-    },
-    plugins: ['ghost', 'react'],
-    extends: [
-        'plugin:ghost/node',
-        'plugin:ghost/ember',
-        'plugin:react/recommended'
-    ],
-    "settings": {
-        "react": {
-            "createClass": "createReactClass",
-            "pragma": "React",
-            "version": "16.0",
-            "flowVersion": "0.53"
+    parser: `@babel/eslint-parser`,
+    parserOptions: {
+        babelOptions: {
+            presets: [`@babel/preset-react`],
         },
-        "propWrapperFunctions": ["forbidExtraProps"]
+        ecmaVersion: 6,
+        ecmaFeatures: {
+            jsx: true,
+            experimentalObjectRestSpread: true,
+        },
+        requireConfigFile: false,
     },
-    "rules": {
-        "ghost/sort-imports-es6-autofix/sort-imports-es6": "off",
-        "ghost/ember/use-ember-get-and-set": "off",
-        "no-console": "off",
-        "no-inner-declarations": "off",
-        "valid-jsdoc": "off",
-        "require-jsdoc": "off",
-        "quotes": ["error", "backtick"],
-        "consistent-return": ["error"],
+    plugins: [`ghost`, `react`],
+    extends: [
+        `plugin:ghost/node`,
+        `plugin:ghost/ember`,
+        `plugin:react/recommended`,
+    ],
+    settings: {
+        react: {
+            createClass: `createReactClass`,
+            pragma: `React`,
+            version: `16.0`,
+            flowVersion: `0.53`,
+        },
+        propWrapperFunctions: [`forbidExtraProps`],
+    },
+    rules: {
+        "ghost/sort-imports-es6-autofix/sort-imports-es6": `off`,
+        "ghost/ember/use-ember-get-and-set": `off`,
+        "no-console": `off`,
+        "no-inner-declarations": `off`,
+        "valid-jsdoc": `off`,
+        "require-jsdoc": `off`,
+        quotes: [`error`, `backtick`],
+        "consistent-return": [`error`],
         "arrow-body-style": [
-            "error",
-            "as-needed",
-            { "requireReturnForObjectLiteral": true }
+            `error`,
+            `as-needed`,
+            { requireReturnForObjectLiteral: true },
         ],
-        "jsx-quotes": ["error", "prefer-double"],
-        "semi": ["error", "never"],
-        "object-curly-spacing": ["error", "always"],
+        "jsx-quotes": [`error`, `prefer-double`],
+        semi: [`error`, `never`],
+        "object-curly-spacing": [`error`, `always`],
         "comma-dangle": [
-            "error",
+            `error`,
             {
-                "arrays": "always-multiline",
-                "objects": "always-multiline",
-                "imports": "always-multiline",
-                "exports": "always-multiline",
-                "functions": "ignore"
-            }
+                arrays: `always-multiline`,
+                objects: `always-multiline`,
+                imports: `always-multiline`,
+                exports: `always-multiline`,
+                functions: `ignore`,
+            },
         ],
         "react/prop-types": [
-            "error",
+            `error`,
             {
-                "ignore": ["children"]
-            }
-        ]
-    }
-};
+                ignore: [`children`],
+            },
+        ],
+    },
+}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -51,7 +51,7 @@ module.exports = {
     siteMetadata: {
         siteUrl: process.env.SITEURL || config.siteUrl,
     },
-    trailingSlash: 'always',
+    trailingSlash: `always`,
     plugins: [
         /**
          *  Content Plugins

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,13 +1,13 @@
-const path = require(`path`);
-const { postsPerPage } = require(`./src/utils/siteConfig`);
-const { paginate } = require(`gatsby-awesome-pagination`);
+const path = require(`path`)
+const { postsPerPage } = require(`./src/utils/siteConfig`)
+const { paginate } = require(`gatsby-awesome-pagination`)
 
 /**
  * Here is the place where Gatsby creates the URLs for all the
  * posts, tags, pages and authors that we fetched from the Ghost site.
  */
 exports.createPages = async ({ graphql, actions }) => {
-    const { createPage } = actions;
+    const { createPage } = actions
 
     const result = await graphql(`
         {
@@ -45,35 +45,35 @@ exports.createPages = async ({ graphql, actions }) => {
                 }
             }
         }
-    `);
+    `)
 
     // Check for any errors
     if (result.errors) {
-        throw new Error(result.errors);
+        throw new Error(result.errors) // eslint-disable-line no-restricted-syntax
     }
 
     // Extract query results
-    const tags = result.data.allGhostTag.edges;
-    const authors = result.data.allGhostAuthor.edges;
-    const pages = result.data.allGhostPage.edges;
-    const posts = result.data.allGhostPost.edges;
+    const tags = result.data.allGhostTag.edges
+    const authors = result.data.allGhostAuthor.edges
+    const pages = result.data.allGhostPage.edges
+    const posts = result.data.allGhostPost.edges
 
     // Load templates
-    const indexTemplate = path.resolve(`./src/templates/index.js`);
-    const tagsTemplate = path.resolve(`./src/templates/tag.js`);
-    const authorTemplate = path.resolve(`./src/templates/author.js`);
-    const pageTemplate = path.resolve(`./src/templates/page.js`);
-    const postTemplate = path.resolve(`./src/templates/post.js`);
+    const indexTemplate = path.resolve(`./src/templates/index.js`)
+    const tagsTemplate = path.resolve(`./src/templates/tag.js`)
+    const authorTemplate = path.resolve(`./src/templates/author.js`)
+    const pageTemplate = path.resolve(`./src/templates/page.js`)
+    const postTemplate = path.resolve(`./src/templates/post.js`)
 
     // Create tag pages
     tags.forEach(({ node }) => {
-        const totalPosts = node.postCount !== null ? node.postCount : 0;
+        const totalPosts = node.postCount !== null ? node.postCount : 0
 
         // This part here defines, that our tag pages will use
         // a `/tag/:slug/` permalink.
-        const url = `/tag/${node.slug}`;
+        const url = `/tag/${node.slug}`
 
-        const items = Array.from({ length: totalPosts });
+        const items = Array.from({ length: totalPosts })
 
         // Create pagination
         paginate({
@@ -81,23 +81,22 @@ exports.createPages = async ({ graphql, actions }) => {
             items: items,
             itemsPerPage: postsPerPage,
             component: tagsTemplate,
-            pathPrefix: ({ pageNumber }) =>
-                pageNumber === 0 ? url : `${url}/page`,
+            pathPrefix: ({ pageNumber }) => (pageNumber === 0 ? url : `${url}/page`),
             context: {
                 slug: node.slug,
             },
-        });
-    });
+        })
+    })
 
     // Create author pages
     authors.forEach(({ node }) => {
-        const totalPosts = node.postCount !== null ? node.postCount : 0;
+        const totalPosts = node.postCount !== null ? node.postCount : 0
 
         // This part here defines, that our author pages will use
         // a `/author/:slug/` permalink.
-        const url = `/author/${node.slug}`;
+        const url = `/author/${node.slug}`
 
-        const items = Array.from({ length: totalPosts });
+        const items = Array.from({ length: totalPosts })
 
         // Create pagination
         paginate({
@@ -105,19 +104,18 @@ exports.createPages = async ({ graphql, actions }) => {
             items: items,
             itemsPerPage: postsPerPage,
             component: authorTemplate,
-            pathPrefix: ({ pageNumber }) =>
-                pageNumber === 0 ? url : `${url}/page`,
+            pathPrefix: ({ pageNumber }) => (pageNumber === 0 ? url : `${url}/page`),
             context: {
                 slug: node.slug,
             },
-        });
-    });
+        })
+    })
 
     // Create pages
     pages.forEach(({ node }) => {
         // This part here defines, that our pages will use
         // a `/:slug/` permalink.
-        node.url = `/${node.slug}/`;
+        node.url = `/${node.slug}/`
 
         createPage({
             path: node.url,
@@ -127,14 +125,14 @@ exports.createPages = async ({ graphql, actions }) => {
                 // in page queries as GraphQL variables.
                 slug: node.slug,
             },
-        });
-    });
+        })
+    })
 
     // Create post pages
     posts.forEach(({ node }) => {
         // This part here defines, that our posts will use
         // a `/:slug/` permalink.
-        node.url = `/${node.slug}/`;
+        node.url = `/${node.slug}/`
 
         createPage({
             path: node.url,
@@ -144,8 +142,8 @@ exports.createPages = async ({ graphql, actions }) => {
                 // in page queries as GraphQL variables.
                 slug: node.slug,
             },
-        });
-    });
+        })
+    })
 
     // Create pagination
     paginate({
@@ -155,18 +153,18 @@ exports.createPages = async ({ graphql, actions }) => {
         component: indexTemplate,
         pathPrefix: ({ pageNumber }) => {
             if (pageNumber === 0) {
-                return `/`;
+                return `/`
             } else {
-                return `/page`;
+                return `/page`
             }
         },
-    });
-};
+    })
+}
 
-exports.onCreateWebpackConfig = ({ stage, actions }) => {
+exports.onCreateWebpackConfig = ({ actions }) => {
     actions.setWebpackConfig({
         resolve: {
-            fallback: { url: require.resolve("url/") },
+            fallback: { url: require.resolve(`url/`) },
         },
-    });
-};
+    })
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "gatsby build",
     "dev": "gatsby develop",
     "lint": "eslint . --ext .js --cache",
+    "lint-fix": "eslint . --ext .js --cache --fix",
     "develop": "gatsby develop",
     "start": "gatsby serve",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
@@ -32,7 +33,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "babel-eslint": "10.1.0",
+    "@babel/eslint-parser": "^7.18.9",
+    "@babel/preset-react": "^7.18.6",
     "eslint": "8.22.0",
     "eslint-plugin-ghost": "2.15.1",
     "eslint-plugin-react": "7.30.1"

--- a/src/components/common/Layout.js
+++ b/src/components/common/Layout.js
@@ -1,14 +1,14 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { Helmet } from "react-helmet";
-import { Link, StaticQuery, graphql } from "gatsby";
-import { GatsbyImage } from "gatsby-plugin-image";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { Helmet } from "react-helmet"
+import { Link, StaticQuery, graphql } from "gatsby"
+import { GatsbyImage } from "gatsby-plugin-image"
 
-import { Navigation } from ".";
-import config from "../../utils/siteConfig";
+import { Navigation } from "."
+import config from "../../utils/siteConfig"
 
 // Styles
-import "../../styles/app.css";
+import "../../styles/app.css"
 
 /**
  * Main layout component
@@ -19,13 +19,13 @@ import "../../styles/app.css";
  *
  */
 const DefaultLayout = ({ data, children, bodyClass, isHome }) => {
-    const site = data.allGhostSettings.edges[0].node;
+    const site = data.allGhostSettings.edges[0].node
     const twitterUrl = site.twitter
         ? `https://twitter.com/${site.twitter.replace(/^@/, ``)}`
-        : null;
+        : null
     const facebookUrl = site.facebook
         ? `https://www.facebook.com/${site.facebook.replace(/^\//, ``)}`
-        : null;
+        : null
 
     return <>
         <Helmet>
@@ -145,7 +145,7 @@ const DefaultLayout = ({ data, children, bodyClass, isHome }) => {
                     <div className="site-foot-nav container">
                         <div className="site-foot-nav-left">
                             <Link to="/">{site.title}</Link> © 2021 &mdash;
-                            Published with{" "}
+                            Published with{` `}
                             <a
                                 className="site-foot-nav-item"
                                 href="https://ghost.org"
@@ -165,8 +165,8 @@ const DefaultLayout = ({ data, children, bodyClass, isHome }) => {
                 </footer>
             </div>
         </div>
-    </>;
-};
+    </>
+}
 
 DefaultLayout.propTypes = {
     children: PropTypes.node.isRequired,
@@ -176,9 +176,9 @@ DefaultLayout.propTypes = {
         file: PropTypes.object,
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
-};
+}
 
-const DefaultLayoutSettingsQuery = (props) => (
+const DefaultLayoutSettingsQuery = props => (
     <StaticQuery
         query={graphql`query GhostSettings {
   allGhostSettings {
@@ -195,8 +195,8 @@ const DefaultLayoutSettingsQuery = (props) => (
   }
 }
 `}
-        render={(data) => <DefaultLayout data={data} {...props} />}
+        render={data => <DefaultLayout data={data} {...props} />}
     />
-);
+)
 
-export default DefaultLayoutSettingsQuery;
+export default DefaultLayoutSettingsQuery

--- a/src/components/common/Navigation.js
+++ b/src/components/common/Navigation.js
@@ -1,6 +1,6 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { Link } from "gatsby";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { Link } from "gatsby"
 
 /**
  * Navigation component
@@ -26,21 +26,21 @@ const Navigation = ({ data, navClass }) => (
                     >
                         {navItem.label}
                     </a>
-                );
+                )
             } else {
                 return (
                     <Link className={navClass} to={navItem.url} key={i}>
                         {navItem.label}
                     </Link>
-                );
+                )
             }
         })}
     </>
-);
+)
 
 Navigation.defaultProps = {
     navClass: `site-nav-item`,
-};
+}
 
 Navigation.propTypes = {
     data: PropTypes.arrayOf(
@@ -50,6 +50,6 @@ Navigation.propTypes = {
         }).isRequired
     ).isRequired,
     navClass: PropTypes.string,
-};
+}
 
-export default Navigation;
+export default Navigation

--- a/src/components/common/Pagination.js
+++ b/src/components/common/Pagination.js
@@ -1,10 +1,10 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { Link } from "gatsby";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { Link } from "gatsby"
 
 const Pagination = ({ pageContext }) => {
     const { previousPagePath, nextPagePath, humanPageNumber, numberOfPages } =
-        pageContext;
+        pageContext
 
     return (
         <nav className="pagination" role="navigation">
@@ -28,11 +28,11 @@ const Pagination = ({ pageContext }) => {
                 )}
             </div>
         </nav>
-    );
-};
+    )
+}
 
 Pagination.propTypes = {
     pageContext: PropTypes.object.isRequired,
-};
+}
 
-export default Pagination;
+export default Pagination

--- a/src/components/common/PostCard.js
+++ b/src/components/common/PostCard.js
@@ -1,12 +1,12 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { Link } from "gatsby";
-import { Tags } from "@tryghost/helpers-gatsby";
-import { readingTime as readingTimeHelper } from "@tryghost/helpers";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { Link } from "gatsby"
+import { Tags } from "@tryghost/helpers-gatsby"
+import { readingTime as readingTimeHelper } from "@tryghost/helpers"
 
 const PostCard = ({ post }) => {
-    const url = `/${post.slug}/`;
-    const readingTime = readingTimeHelper(post);
+    const url = `/${post.slug}/`
+    const readingTime = readingTimeHelper(post)
 
     return (
         <Link to={url} className="post-card">
@@ -21,7 +21,7 @@ const PostCard = ({ post }) => {
                 )}
                 {post.tags && (
                     <div className="post-card-tags">
-                        {" "}
+                        {` `}
                         <Tags
                             post={post}
                             visibility="public"
@@ -57,8 +57,8 @@ const PostCard = ({ post }) => {
                 </div>
             </footer>
         </Link>
-    );
-};
+    )
+}
 
 PostCard.propTypes = {
     post: PropTypes.shape({
@@ -77,6 +77,6 @@ PostCard.propTypes = {
             profile_image: PropTypes.string,
         }).isRequired,
     }).isRequired,
-};
+}
 
-export default PostCard;
+export default PostCard

--- a/src/components/common/meta/ArticleMeta.js
+++ b/src/components/common/meta/ArticleMeta.js
@@ -1,33 +1,33 @@
-import * as React from "react";
-import { Helmet } from "react-helmet";
-import { StaticQuery, graphql } from "gatsby";
-import PropTypes from "prop-types";
-import _ from "lodash";
-import url from "url";
+import * as React from "react"
+import { Helmet } from "react-helmet"
+import { StaticQuery, graphql } from "gatsby"
+import PropTypes from "prop-types"
+import _ from "lodash"
+import url from "url"
 
-import getAuthorProperties from "./getAuthorProperties";
-import ImageMeta from "./ImageMeta";
-import config from "../../../utils/siteConfig";
+import getAuthorProperties from "./getAuthorProperties"
+import ImageMeta from "./ImageMeta"
+import config from "../../../utils/siteConfig"
 
-import { tags as tagsHelper } from "@tryghost/helpers";
+import { tags as tagsHelper } from "@tryghost/helpers"
 
 const ArticleMetaGhost = ({ data, settings, canonical }) => {
-    const ghostPost = data;
-    settings = settings.allGhostSettings.edges[0].node;
+    const ghostPost = data
+    settings = settings.allGhostSettings.edges[0].node
 
-    const author = getAuthorProperties(ghostPost.primary_author);
+    const author = getAuthorProperties(ghostPost.primary_author)
     const publicTags = _.map(
-        tagsHelper(ghostPost, { visibility: `public`, fn: (tag) => tag }),
+        tagsHelper(ghostPost, { visibility: `public`, fn: tag => tag }),
         `name`
-    );
-    const primaryTag = publicTags[0] || ``;
+    )
+    const primaryTag = publicTags[0] || ``
     const shareImage = ghostPost.feature_image
         ? ghostPost.feature_image
-        : _.get(settings, `cover_image`, null);
+        : _.get(settings, `cover_image`, null)
     const publisherLogo =
         settings.logo || config.siteIcon
             ? url.resolve(config.siteUrl, settings.logo || config.siteIcon)
-            : null;
+            : null
 
     const jsonLd = {
         "@context": `https://schema.org/`,
@@ -45,11 +45,11 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
         dateModified: ghostPost.updated_at,
         image: shareImage
             ? {
-                  "@type": `ImageObject`,
-                  url: shareImage,
-                  width: config.shareImageWidth,
-                  height: config.shareImageHeight,
-              }
+                "@type": `ImageObject`,
+                url: shareImage,
+                width: config.shareImageWidth,
+                height: config.shareImageHeight,
+            }
             : undefined,
         publisher: {
             "@type": `Organization`,
@@ -66,7 +66,7 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
             "@type": `WebPage`,
             "@id": config.siteUrl,
         },
-    };
+    }
 
     return (
         <>
@@ -159,8 +159,8 @@ const ArticleMetaGhost = ({ data, settings, canonical }) => {
             </Helmet>
             <ImageMeta image={shareImage} />
         </>
-    );
-};
+    )
+}
 
 ArticleMetaGhost.propTypes = {
     data: PropTypes.shape({
@@ -194,9 +194,9 @@ ArticleMetaGhost.propTypes = {
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
     canonical: PropTypes.string.isRequired,
-};
+}
 
-const ArticleMetaQuery = (props) => (
+const ArticleMetaQuery = props => (
     <StaticQuery
         query={graphql`
             query GhostSettingsArticleMeta {
@@ -209,8 +209,8 @@ const ArticleMetaQuery = (props) => (
                 }
             }
         `}
-        render={(data) => <ArticleMetaGhost settings={data} {...props} />}
+        render={data => <ArticleMetaGhost settings={data} {...props} />}
     />
-);
+)
 
-export default ArticleMetaQuery;
+export default ArticleMetaQuery

--- a/src/components/common/meta/AuthorMeta.js
+++ b/src/components/common/meta/AuthorMeta.js
@@ -1,21 +1,21 @@
-import * as React from "react";
-import { Helmet } from "react-helmet";
-import PropTypes from "prop-types";
-import _ from "lodash";
-import { StaticQuery, graphql } from "gatsby";
+import * as React from "react"
+import { Helmet } from "react-helmet"
+import PropTypes from "prop-types"
+import _ from "lodash"
+import { StaticQuery, graphql } from "gatsby"
 
-import ImageMeta from "./ImageMeta";
-import getAuthorProperties from "./getAuthorProperties";
-import config from "../../../utils/siteConfig";
+import ImageMeta from "./ImageMeta"
+import getAuthorProperties from "./getAuthorProperties"
+import config from "../../../utils/siteConfig"
 
 const AuthorMeta = ({ data, settings, canonical }) => {
-    settings = settings.allGhostSettings.edges[0].node;
+    settings = settings.allGhostSettings.edges[0].node
 
-    const author = getAuthorProperties(data);
-    const shareImage = author.image || _.get(settings, `cover_image`, null);
-    const title = `${data.name} - ${settings.title}`;
+    const author = getAuthorProperties(data)
+    const shareImage = author.image || _.get(settings, `cover_image`, null)
+    const title = `${data.name} - ${settings.title}`
     const description =
-        data.bio || config.siteDescriptionMeta || settings.description;
+        data.bio || config.siteDescriptionMeta || settings.description
 
     const jsonLd = {
         "@context": `https://schema.org/`,
@@ -25,18 +25,18 @@ const AuthorMeta = ({ data, settings, canonical }) => {
         url: canonical,
         image: shareImage
             ? {
-                  "@type": `ImageObject`,
-                  url: shareImage,
-                  width: config.shareImageWidth,
-                  height: config.shareImageHeight,
-              }
+                "@type": `ImageObject`,
+                url: shareImage,
+                width: config.shareImageWidth,
+                height: config.shareImageHeight,
+            }
             : undefined,
         mainEntityOfPage: {
             "@type": `WebPage`,
             "@id": config.siteUrl,
         },
         description,
-    };
+    }
 
     return (
         <>
@@ -70,8 +70,8 @@ const AuthorMeta = ({ data, settings, canonical }) => {
             </Helmet>
             <ImageMeta image={shareImage} />
         </>
-    );
-};
+    )
+}
 
 AuthorMeta.propTypes = {
     data: PropTypes.shape({
@@ -89,9 +89,9 @@ AuthorMeta.propTypes = {
         allGhostSettings: PropTypes.object.isRequired,
     }).isRequired,
     canonical: PropTypes.string.isRequired,
-};
+}
 
-const AuthorMetaQuery = (props) => (
+const AuthorMetaQuery = props => (
     <StaticQuery
         query={graphql`
             query GhostSettingsAuthorMeta {
@@ -104,8 +104,8 @@ const AuthorMetaQuery = (props) => (
                 }
             }
         `}
-        render={(data) => <AuthorMeta settings={data} {...props} />}
+        render={data => <AuthorMeta settings={data} {...props} />}
     />
-);
+)
 
-export default AuthorMetaQuery;
+export default AuthorMetaQuery

--- a/src/components/common/meta/ImageMeta.js
+++ b/src/components/common/meta/ImageMeta.js
@@ -1,11 +1,11 @@
-import * as React from "react";
-import { Helmet } from "react-helmet";
-import PropTypes from "prop-types";
-import config from "../../../utils/siteConfig";
+import * as React from "react"
+import { Helmet } from "react-helmet"
+import PropTypes from "prop-types"
+import config from "../../../utils/siteConfig"
 
 const ImageMeta = ({ image }) => {
     if (!image) {
-        return null;
+        return null
     }
 
     return (
@@ -19,11 +19,11 @@ const ImageMeta = ({ image }) => {
                 content={config.shareImageHeight}
             />
         </Helmet>
-    );
-};
+    )
+}
 
 ImageMeta.propTypes = {
     image: PropTypes.string,
-};
+}
 
-export default ImageMeta;
+export default ImageMeta

--- a/src/components/common/meta/MetaData.js
+++ b/src/components/common/meta/MetaData.js
@@ -1,12 +1,12 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { StaticQuery, graphql } from "gatsby";
-import url from "url";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { StaticQuery, graphql } from "gatsby"
+import url from "url"
 
-import config from "../../../utils/siteConfig";
-import ArticleMeta from "./ArticleMeta";
-import WebsiteMeta from "./WebsiteMeta";
-import AuthorMeta from "./AuthorMeta";
+import config from "../../../utils/siteConfig"
+import ArticleMeta from "./ArticleMeta"
+import WebsiteMeta from "./WebsiteMeta"
+import AuthorMeta from "./AuthorMeta"
 
 /**
  * MetaData will generate all relevant meta data information incl.
@@ -14,18 +14,18 @@ import AuthorMeta from "./AuthorMeta";
  *
  */
 const MetaData = ({ data, settings, title, description, image, location }) => {
-    const canonical = url.resolve(config.siteUrl, location.pathname);
-    const { ghostPost, ghostTag, ghostAuthor, ghostPage } = data;
-    settings = settings.allGhostSettings.edges[0].node;
+    const canonical = url.resolve(config.siteUrl, location.pathname)
+    const { ghostPost, ghostTag, ghostAuthor, ghostPage } = data
+    settings = settings.allGhostSettings.edges[0].node
 
     if (ghostPost) {
-        return <ArticleMeta data={ghostPost} canonical={canonical} />;
+        return <ArticleMeta data={ghostPost} canonical={canonical} />
     } else if (ghostTag) {
         return (
             <WebsiteMeta data={ghostTag} canonical={canonical} type="Series" />
-        );
+        )
     } else if (ghostAuthor) {
-        return <AuthorMeta data={ghostAuthor} canonical={canonical} />;
+        return <AuthorMeta data={ghostAuthor} canonical={canonical} />
     } else if (ghostPage) {
         return (
             <WebsiteMeta
@@ -33,14 +33,14 @@ const MetaData = ({ data, settings, title, description, image, location }) => {
                 canonical={canonical}
                 type="WebSite"
             />
-        );
+        )
     } else {
-        title = title || config.siteTitleMeta || settings.title;
+        title = title || config.siteTitleMeta || settings.title
         description =
-            description || config.siteDescriptionMeta || settings.description;
-        image = image || settings.cover_image || null;
+            description || config.siteDescriptionMeta || settings.description
+        image = image || settings.cover_image || null
 
-        image = image ? url.resolve(config.siteUrl, image) : null;
+        image = image ? url.resolve(config.siteUrl, image) : null
 
         return (
             <WebsiteMeta
@@ -51,13 +51,13 @@ const MetaData = ({ data, settings, title, description, image, location }) => {
                 image={image}
                 type="WebSite"
             />
-        );
+        )
     }
-};
+}
 
 MetaData.defaultProps = {
     data: {},
-};
+}
 
 MetaData.propTypes = {
     data: PropTypes.shape({
@@ -68,6 +68,9 @@ MetaData.propTypes = {
     }).isRequired,
     settings: PropTypes.shape({
         allGhostSettings: PropTypes.object.isRequired,
+        cover_image: PropTypes.string,
+        description: PropTypes.string,
+        title: PropTypes.string,
     }).isRequired,
     location: PropTypes.shape({
         pathname: PropTypes.string.isRequired,
@@ -75,9 +78,9 @@ MetaData.propTypes = {
     title: PropTypes.string,
     description: PropTypes.string,
     image: PropTypes.string,
-};
+}
 
-const MetaDataQuery = (props) => (
+const MetaDataQuery = props => (
     <StaticQuery
         query={graphql`
             query GhostSettingsMetaData {
@@ -91,8 +94,8 @@ const MetaDataQuery = (props) => (
                 }
             }
         `}
-        render={(data) => <MetaData settings={data} {...props} />}
+        render={data => <MetaData settings={data} {...props} />}
     />
-);
+)
 
-export default MetaDataQuery;
+export default MetaDataQuery

--- a/src/components/common/meta/WebsiteMeta.js
+++ b/src/components/common/meta/WebsiteMeta.js
@@ -1,12 +1,12 @@
-import * as React from "react";
-import { Helmet } from "react-helmet";
-import PropTypes from "prop-types";
-import _ from "lodash";
-import { StaticQuery, graphql } from "gatsby";
-import url from "url";
+import * as React from "react"
+import { Helmet } from "react-helmet"
+import PropTypes from "prop-types"
+import _ from "lodash"
+import { StaticQuery, graphql } from "gatsby"
+import url from "url"
 
-import ImageMeta from "./ImageMeta";
-import config from "../../../utils/siteConfig";
+import ImageMeta from "./ImageMeta"
+import config from "../../../utils/siteConfig"
 
 const WebsiteMeta = ({
     data,
@@ -17,26 +17,26 @@ const WebsiteMeta = ({
     image,
     type,
 }) => {
-    settings = settings.allGhostSettings.edges[0].node;
+    settings = settings.allGhostSettings.edges[0].node
 
     const publisherLogo = url.resolve(
         config.siteUrl,
         settings.logo || config.siteIcon
-    );
+    )
     let shareImage =
-        image || data.feature_image || _.get(settings, `cover_image`, null);
+        image || data.feature_image || _.get(settings, `cover_image`, null)
 
-    shareImage = shareImage ? url.resolve(config.siteUrl, shareImage) : null;
+    shareImage = shareImage ? url.resolve(config.siteUrl, shareImage) : null
 
     description =
         description ||
         data.meta_description ||
         data.description ||
         config.siteDescriptionMeta ||
-        settings.description;
+        settings.description
     title = `${title || data.meta_title || data.name || data.title} - ${
         settings.title
-    }`;
+    }`
 
     const jsonLd = {
         "@context": `https://schema.org/`,
@@ -44,11 +44,11 @@ const WebsiteMeta = ({
         url: canonical,
         image: shareImage
             ? {
-                  "@type": `ImageObject`,
-                  url: shareImage,
-                  width: config.shareImageWidth,
-                  height: config.shareImageHeight,
-              }
+                "@type": `ImageObject`,
+                url: shareImage,
+                width: config.shareImageWidth,
+                height: config.shareImageHeight,
+            }
             : undefined,
         publisher: {
             "@type": `Organization`,
@@ -65,7 +65,7 @@ const WebsiteMeta = ({
             "@id": config.siteUrl,
         },
         description,
-    };
+    }
 
     return (
         <>
@@ -99,8 +99,8 @@ const WebsiteMeta = ({
             </Helmet>
             <ImageMeta image={shareImage} />
         </>
-    );
-};
+    )
+}
 
 WebsiteMeta.propTypes = {
     data: PropTypes.shape({
@@ -125,9 +125,9 @@ WebsiteMeta.propTypes = {
     description: PropTypes.string,
     image: PropTypes.string,
     type: PropTypes.oneOf([`WebSite`, `Series`]).isRequired,
-};
+}
 
-const WebsiteMetaQuery = (props) => (
+const WebsiteMetaQuery = props => (
     <StaticQuery
         query={graphql`
             query GhostSettingsWebsiteMeta {
@@ -140,8 +140,8 @@ const WebsiteMetaQuery = (props) => (
                 }
             }
         `}
-        render={(data) => <WebsiteMeta settings={data} {...props} />}
+        render={data => <WebsiteMeta settings={data} {...props} />}
     />
-);
+)
 
-export default WebsiteMetaQuery;
+export default WebsiteMetaQuery

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,6 +1,6 @@
-import * as React from "react";
-import { Link } from "gatsby";
-import { Layout } from "../components/common";
+import * as React from "react"
+import { Link } from "gatsby"
+import { Layout } from "../components/common"
 
 const NotFoundPage = () => (
     <Layout>
@@ -14,6 +14,6 @@ const NotFoundPage = () => (
             </article>
         </div>
     </Layout>
-);
+)
 
-export default NotFoundPage;
+export default NotFoundPage

--- a/src/templates/author.js
+++ b/src/templates/author.js
@@ -1,9 +1,9 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
 
-import { Layout, PostCard, Pagination } from "../components/common";
-import { MetaData } from "../components/common/meta";
+import { Layout, PostCard, Pagination } from "../components/common"
+import { MetaData } from "../components/common/meta"
 
 /**
  * Author page (/author/:slug)
@@ -12,14 +12,14 @@ import { MetaData } from "../components/common/meta";
  *
  */
 const Author = ({ data, location, pageContext }) => {
-    const author = data.ghostAuthor;
-    const posts = data.allGhostPost.edges;
+    const author = data.ghostAuthor
+    const posts = data.allGhostPost.edges
     const twitterUrl = author.twitter
         ? `https://twitter.com/${author.twitter.replace(/^@/, ``)}`
-        : null;
+        : null
     const facebookUrl = author.facebook
         ? `https://www.facebook.com/${author.facebook.replace(/^\//, ``)}`
-        : null;
+        : null
 
     return (
         <>
@@ -82,8 +82,8 @@ const Author = ({ data, location, pageContext }) => {
                 </div>
             </Layout>
         </>
-    );
-};
+    )
+}
 
 Author.propTypes = {
     data: PropTypes.shape({
@@ -103,9 +103,9 @@ Author.propTypes = {
         pathname: PropTypes.string.isRequired,
     }).isRequired,
     pageContext: PropTypes.object,
-};
+}
 
-export default Author;
+export default Author
 
 export const pageQuery = graphql`
     query GhostAuthorQuery($slug: String!, $limit: Int!, $skip: Int!) {
@@ -125,4 +125,4 @@ export const pageQuery = graphql`
             }
         }
     }
-`;
+`

--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -1,9 +1,9 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
 
-import { Layout, PostCard, Pagination } from "../components/common";
-import { MetaData } from "../components/common/meta";
+import { Layout, PostCard, Pagination } from "../components/common"
+import { MetaData } from "../components/common/meta"
 
 /**
  * Main index page (home page)
@@ -14,7 +14,7 @@ import { MetaData } from "../components/common/meta";
  *
  */
 const Index = ({ data, location, pageContext }) => {
-    const posts = data.allGhostPost.edges;
+    const posts = data.allGhostPost.edges
 
     return (
         <>
@@ -31,8 +31,8 @@ const Index = ({ data, location, pageContext }) => {
                 </div>
             </Layout>
         </>
-    );
-};
+    )
+}
 
 Index.propTypes = {
     data: PropTypes.shape({
@@ -42,9 +42,9 @@ Index.propTypes = {
         pathname: PropTypes.string.isRequired,
     }).isRequired,
     pageContext: PropTypes.object,
-};
+}
 
-export default Index;
+export default Index
 
 // This page query loads all posts sorted descending by published date
 // The `limit` and `skip` values are used for pagination
@@ -62,4 +62,4 @@ export const pageQuery = graphql`
             }
         }
     }
-`;
+`

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -1,10 +1,10 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
-import { Helmet } from "react-helmet";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
+import { Helmet } from "react-helmet"
 
-import { Layout } from "../components/common";
-import { MetaData } from "../components/common/meta";
+import { Layout } from "../components/common"
+import { MetaData } from "../components/common/meta"
 
 /**
  * Single page (/:slug)
@@ -13,7 +13,7 @@ import { MetaData } from "../components/common/meta";
  *
  */
 const Page = ({ data, location }) => {
-    const page = data.ghostPage;
+    const page = data.ghostPage
 
     return (
         <>
@@ -35,8 +35,8 @@ const Page = ({ data, location }) => {
                 </div>
             </Layout>
         </>
-    );
-};
+    )
+}
 
 Page.propTypes = {
     data: PropTypes.shape({
@@ -48,9 +48,9 @@ Page.propTypes = {
         }).isRequired,
     }).isRequired,
     location: PropTypes.object.isRequired,
-};
+}
 
-export default Page;
+export default Page
 
 export const postQuery = graphql`
     query ($slug: String!) {
@@ -58,4 +58,4 @@ export const postQuery = graphql`
             ...GhostPageFields
         }
     }
-`;
+`

--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -1,10 +1,10 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
-import { Helmet } from "react-helmet";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
+import { Helmet } from "react-helmet"
 
-import { Layout } from "../components/common";
-import { MetaData } from "../components/common/meta";
+import { Layout } from "../components/common"
+import { MetaData } from "../components/common/meta"
 
 /**
  * Single post view (/:slug)
@@ -13,7 +13,7 @@ import { MetaData } from "../components/common/meta";
  *
  */
 const Post = ({ data, location }) => {
-    const post = data.ghostPost;
+    const post = data.ghostPost
 
     return (
         <>
@@ -45,8 +45,8 @@ const Post = ({ data, location }) => {
                 </div>
             </Layout>
         </>
-    );
-};
+    )
+}
 
 Post.propTypes = {
     data: PropTypes.shape({
@@ -58,9 +58,9 @@ Post.propTypes = {
         }).isRequired,
     }).isRequired,
     location: PropTypes.object.isRequired,
-};
+}
 
-export default Post;
+export default Post
 
 export const postQuery = graphql`
     query ($slug: String!) {
@@ -68,4 +68,4 @@ export const postQuery = graphql`
             ...GhostPostFields
         }
     }
-`;
+`

--- a/src/templates/tag.js
+++ b/src/templates/tag.js
@@ -1,9 +1,9 @@
-import * as React from "react";
-import PropTypes from "prop-types";
-import { graphql } from "gatsby";
+import * as React from "react"
+import PropTypes from "prop-types"
+import { graphql } from "gatsby"
 
-import { Layout, PostCard, Pagination } from "../components/common";
-import { MetaData } from "../components/common/meta";
+import { Layout, PostCard, Pagination } from "../components/common"
+import { MetaData } from "../components/common/meta"
 
 /**
  * Tag page (/tag/:slug)
@@ -12,8 +12,8 @@ import { MetaData } from "../components/common/meta";
  *
  */
 const Tag = ({ data, location, pageContext }) => {
-    const tag = data.ghostTag;
-    const posts = data.allGhostPost.edges;
+    const tag = data.ghostTag
+    const posts = data.allGhostPost.edges
 
     return (
         <>
@@ -34,8 +34,8 @@ const Tag = ({ data, location, pageContext }) => {
                 </div>
             </Layout>
         </>
-    );
-};
+    )
+}
 
 Tag.propTypes = {
     data: PropTypes.shape({
@@ -49,9 +49,9 @@ Tag.propTypes = {
         pathname: PropTypes.string.isRequired,
     }).isRequired,
     pageContext: PropTypes.object,
-};
+}
 
-export default Tag;
+export default Tag
 
 export const pageQuery = graphql`
     query GhostTagQuery($slug: String!, $limit: Int!, $skip: Int!) {
@@ -71,4 +71,4 @@ export const pageQuery = graphql`
             }
         }
     }
-`;
+`

--- a/src/utils/rss/generate-feed.js
+++ b/src/utils/rss/generate-feed.js
@@ -1,14 +1,14 @@
-const cheerio = require(`cheerio`);
-const tagsHelper = require(`@tryghost/helpers`).tags;
-const _ = require(`lodash`);
+const cheerio = require(`cheerio`)
+const tagsHelper = require(`@tryghost/helpers`).tags
+const _ = require(`lodash`)
 
 const generateItem = function generateItem(siteUrl, post) {
-    const itemUrl = post.canonical_url || `${siteUrl}/${post.slug}/`;
-    const html = post.html;
+    const itemUrl = post.canonical_url || `${siteUrl}/${post.slug}/`
+    const html = post.html
     const htmlContent = cheerio.load(html, {
         decodeEntities: false,
         xmlMode: true,
-    });
+    })
     const item = {
         title: post.title,
         description: post.excerpt,
@@ -16,16 +16,16 @@ const generateItem = function generateItem(siteUrl, post) {
         url: itemUrl,
         date: post.published_at,
         categories: _.map(
-            tagsHelper(post, { visibility: `public`, fn: (tag) => tag }),
+            tagsHelper(post, { visibility: `public`, fn: tag => tag }),
             `name`
         ),
         author: post.primary_author ? post.primary_author.name : null,
         custom_elements: [],
-    };
-    let imageUrl;
+    }
+    let imageUrl
 
     if (post.feature_image) {
-        imageUrl = post.feature_image;
+        imageUrl = post.feature_image
 
         // Add a media content tag
         item.custom_elements.push({
@@ -35,35 +35,33 @@ const generateItem = function generateItem(siteUrl, post) {
                     medium: `image`,
                 },
             },
-        });
+        })
 
         // Also add the image to the content, because not all readers support media:content
         htmlContent(`p`)
             .first()
-            .before(`<img src="` + imageUrl + `" />`);
-        htmlContent(`img`).attr(`alt`, post.title);
+            .before(`<img src="` + imageUrl + `" />`)
+        htmlContent(`img`).attr(`alt`, post.title)
     }
 
     item.custom_elements.push({
         "content:encoded": {
             _cdata: htmlContent.html(),
         },
-    });
-    return item;
-};
+    })
+    return item
+}
 
 const generateRSSFeed = function generateRSSFeed(siteConfig) {
     return {
         title: `No title`,
-        serialize: ({ query: { allGhostPost } }) =>
-            allGhostPost.edges.map((edge) =>
-                Object.assign({}, generateItem(siteConfig.siteUrl, edge.node))
-            ),
+        serialize: ({ query: { allGhostPost } }) => allGhostPost.edges.map(edge => Object.assign({}, generateItem(siteConfig.siteUrl, edge.node))
+        ),
         setup: ({ query: { allGhostSettings } }) => {
             const siteTitle =
-                allGhostSettings.edges[0].node.title || `No Title`;
+                allGhostSettings.edges[0].node.title || `No Title`
             const siteDescription =
-                allGhostSettings.edges[0].node.description || `No Description`;
+                allGhostSettings.edges[0].node.description || `No Description`
             const feed = {
                 title: siteTitle,
                 description: siteDescription,
@@ -77,10 +75,10 @@ const generateRSSFeed = function generateRSSFeed(siteConfig) {
                     content: `http://purl.org/rss/1.0/modules/content/`,
                     media: `http://search.yahoo.com/mrss/`,
                 },
-            };
+            }
             return {
                 ...feed,
-            };
+            }
         },
         query: `
         {
@@ -130,7 +128,7 @@ const generateRSSFeed = function generateRSSFeed(siteConfig) {
         }
   `,
         output: `/rss`,
-    };
-};
+    }
+}
 
-module.exports = generateRSSFeed;
+module.exports = generateRSSFeed

--- a/src/utils/siteConfig.js
+++ b/src/utils/siteConfig.js
@@ -1,4 +1,4 @@
-const config = require(`../../.ghost.json`).production;
+const config = require(`../../.ghost.json`).production
 module.exports = {
     siteUrl:
         process.env.NODE_ENV === `production`
@@ -17,4 +17,4 @@ module.exports = {
     siteIcon: `favicon.png`, // Logo in /static dir used for SEO, RSS, and App manifest
     backgroundColor: `#e9e9e9`, // Used for Offline Manifest
     themeColor: `#15171A`, // Used for Offline Manifest
-};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,7 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/eslint-parser@^7.15.4":
+"@babel/eslint-parser@^7.15.4", "@babel/eslint-parser@^7.18.9":
   version "7.18.9"
   resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.18.9.tgz#255a63796819a97b7578751bb08ab9f2a375a031"
   integrity sha512-KzSGpMBggz4fKbRbWLNyPVTuQr6cmCcBhOyXTw/fieOVaw5oYAwcAj4a7UKcDYCPxQq+CG1NCDZH9e2JTXquiQ==
@@ -308,7 +308,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.14.0", "@babel/parser@^7.15.5", "@babel/parser@^7.16.8", "@babel/parser@^7.18.10", "@babel/parser@^7.18.11", "@babel/parser@^7.7.0":
+"@babel/parser@^7.14.0", "@babel/parser@^7.15.5", "@babel/parser@^7.16.8", "@babel/parser@^7.18.10", "@babel/parser@^7.18.11":
   version "7.18.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.11.tgz#68bb07ab3d380affa9a3f96728df07969645d2d9"
   integrity sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==
@@ -990,7 +990,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@^7.14.0":
+"@babel/preset-react@^7.14.0", "@babel/preset-react@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.18.6.tgz#979f76d6277048dc19094c217b507f3ad517dd2d"
   integrity sha512-zXr6atUmyYdiWRVLOZahakYmOBHtWc2WGCkP8PYTgZi0iJXDY2CN180TdrIW4OGOAdLc7TifzDIvtx6izaRIzg==
@@ -1042,7 +1042,7 @@
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
 
-"@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.10", "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.9", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.14.0", "@babel/traverse@^7.15.4", "@babel/traverse@^7.16.8", "@babel/traverse@^7.18.10", "@babel/traverse@^7.18.11", "@babel/traverse@^7.18.9":
   version "7.18.11"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.11.tgz#3d51f2afbd83ecf9912bcbb5c4d94e3d2ddaa16f"
   integrity sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==
@@ -1058,7 +1058,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.15.4", "@babel/types@^7.16.8", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.0.0", "@babel/types@^7.0.0-beta.49", "@babel/types@^7.15.4", "@babel/types@^7.16.8", "@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.4.4":
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.10.tgz#4908e81b6b339ca7c6b7a555a5fc29446f26dde6"
   integrity sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==
@@ -3403,18 +3403,6 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-eslint@10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
-
 babel-extract-comments@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/babel-extract-comments/-/babel-extract-comments-1.0.0.tgz#0a2aedf81417ed391b85e18b4614e693a0351a21"
@@ -5425,7 +5413,7 @@ eslint-utils@^3.0.0:
   dependencies:
     eslint-visitor-keys "^2.0.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
@@ -10052,7 +10040,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==


### PR DESCRIPTION
refs/closes #532

Others encountering this issue have [resolved the problem](https://stackoverflow.com/questions/70386909/problem-with-babel-eslint-parsing-error-require-of-es-module) by migrating from `babel-eslint` (deprecated as of March 2020) to `@babel/eslint-parser`.

- This pull request completes the migration from `babel-eslint` to `@babel/eslint-parser`.
- A `lint-fix` script was added to package.json for future convenience.
- Automated lint fixes were applied
- Also includes a few manual lint fixes for `prop-types` and an inline eslint disable

`yarn run lint` now passes but it wasn't clear if the eslint rules were configured as desired. There's obviously lots of automated fixes in this PR that could possibly be resolved by changing the config rather than changing the code. I'm happy to change the eslint rules to whatever the project maintainers prefer and update this PR accordingly.